### PR TITLE
Fix for chunked response from jsreport server

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,6 +51,18 @@ Client.prototype.render = function (req, options, cb) {
   responseStream.on('error', function (err) {
     cb(err)
   })
+  
+  // collecting chunked response
+  var responseBuffer
+  responseStream.on('data', function(data) {
+    if (Buffer.isBuffer(responseBuffer)) {
+      responseBuffer = Buffer.concat([responseBuffer, data])
+    } else if(responseBuffer) {
+      responseBuffer += data
+    } else {
+      responseBuffer = data
+    }
+  });
 
   responseStream.on('response', function (response) {
     response.on('error', function (err) {
@@ -72,12 +84,9 @@ Client.prototype.render = function (req, options, cb) {
       })
     }
 
-    response.body = function (cb) { responseToBuffer(response, cb) }
-    cb(null, response)
+    response.body = function (cb) { cb(responseBuffer) }
+    response.on('end', function() {
+      cb(null, response)
+    })
   })
-}
-
-function responseToBuffer (response, cb) {
-  var writeStream = concat(cb)
-  response.pipe(writeStream)
 }


### PR DESCRIPTION
Probably it was changed in jsreport server to return PDFs in the chunked response.
Current version of nodejs-client returns only the last chunk.
I tried to make a fix which doesn't broke previous version